### PR TITLE
Add configurable temperature unit support

### DIFF
--- a/sparkweather-test.el
+++ b/sparkweather-test.el
@@ -390,6 +390,47 @@
       (should (= (length overlaps) 1))
       (should (equal (car overlaps) '("All Day" "Lunch" 12 14))))))
 
+(ert-deftest sparkweather-test-temperature-unit-symbol-celsius ()
+  "Temperature unit symbol returns °C for celsius."
+  (let ((sparkweather-temperature-unit 'celsius))
+    (should (equal (sparkweather--temperature-unit-symbol) "°C"))))
+
+(ert-deftest sparkweather-test-temperature-unit-symbol-fahrenheit ()
+  "Temperature unit symbol returns °F for fahrenheit."
+  (let ((sparkweather-temperature-unit 'fahrenheit))
+    (should (equal (sparkweather--temperature-unit-symbol) "°F"))))
+
+(ert-deftest sparkweather-test-temperature-unit-symbol-c ()
+  "Temperature unit symbol returns °C for \"C\" string."
+  (let ((sparkweather-temperature-unit "C"))
+    (should (equal (sparkweather--temperature-unit-symbol) "°C"))))
+
+(ert-deftest sparkweather-test-temperature-unit-symbol-f ()
+  "Temperature unit symbol returns °F for \"F\" string."
+  (let ((sparkweather-temperature-unit "F"))
+    (should (equal (sparkweather--temperature-unit-symbol) "°F"))))
+
+(ert-deftest sparkweather-test-convert-temperature-celsius ()
+  "Temperature conversion with celsius returns value unchanged."
+  (let ((sparkweather-temperature-unit 'celsius))
+    (should (= (sparkweather--convert-temperature 0) 0))
+    (should (= (sparkweather--convert-temperature 20) 20))
+    (should (= (sparkweather--convert-temperature -10) -10))))
+
+(ert-deftest sparkweather-test-convert-temperature-fahrenheit ()
+  "Temperature conversion with fahrenheit converts correctly."
+  (let ((sparkweather-temperature-unit 'fahrenheit))
+    (should (= (sparkweather--convert-temperature 0) 32))
+    (should (= (sparkweather--convert-temperature 100) 212))
+    (should (= (sparkweather--convert-temperature -40) -40))
+    (should (= (sparkweather--convert-temperature 20) 68))))
+
+(ert-deftest sparkweather-test-convert-temperature-f-string ()
+  "Temperature conversion with \"F\" string converts correctly."
+  (let ((sparkweather-temperature-unit "F"))
+    (should (= (sparkweather--convert-temperature 0) 32))
+    (should (= (sparkweather--convert-temperature 20) 68))))
+
 (provide 'sparkweather-test)
 
 ;;; sparkweather-test.el ends here


### PR DESCRIPTION
Users can now configure sparkweather to display temperatures in Fahrenheit or Celsius via the new sparkweather-temperature-unit customization variable.

The variable accepts 'celsius, 'fahrenheit, "C", or "F" and defaults to celsius for backward compatibility.

Implementation converts API data (always Celsius) to Fahrenheit at display time rather than requesting different units from the API. This approach avoids additional API parameters while providing the flexibility users need.

Changes include:
- New defcustom sparkweather-temperature-unit with choice type
- Helper function sparkweather--temperature-unit-symbol returns display symbol (°C or °F)
- Helper function sparkweather--convert-temperature handles conversion using standard formula (C × 1.8 + 32)
- Modified sparkweather--create-entries to convert temperatures for both display ranges and sparkline scaling
- Added comprehensive test coverage for symbol selection and temperature conversion across all valid unit values